### PR TITLE
Unpin the bitflags dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "cocoa"
 crate-type = ["rlib"]
 
 [dependencies]
-bitflags = "0.1"
+bitflags = "*"
 libc = "*"
 core-graphics = "*"
 objc = "0.1"


### PR DESCRIPTION
It causes Servo to depend on two versions of the bitflags crate (0.1 and 0.2).