### PR TITLE
Do app activation in example through NSRunningApplication to get menubar to work

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,6 +1,6 @@
 extern crate cocoa;
 
-use cocoa::base::{selector, nil, /*YES, */ NO};
+use cocoa::base::{selector, nil, NO};
 use cocoa::foundation::{NSUInteger, NSRect, NSPoint, NSSize,
 						NSAutoreleasePool, NSProcessInfo, NSString};
 use cocoa::appkit::{NSApp,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,12 +1,13 @@
 extern crate cocoa;
 
-use cocoa::base::{selector, nil, YES, NO};
+use cocoa::base::{selector, nil, /*YES, */ NO};
 use cocoa::foundation::{NSUInteger, NSRect, NSPoint, NSSize,
 						NSAutoreleasePool, NSProcessInfo, NSString};
 use cocoa::appkit::{NSApp,
 					NSApplication, NSApplicationActivationPolicyRegular,
 					NSWindow, NSTitledWindowMask, NSBackingStoreBuffered,
-					NSMenu, NSMenuItem};
+					NSMenu, NSMenuItem, NSRunningApplication,
+					NSApplicationActivateIgnoringOtherApps};
 
 fn main() {
 	unsafe {
@@ -49,8 +50,8 @@ fn main() {
 		let title = NSString::alloc(nil).init_str("Hello World!");
 		window.setTitle_(title);
 		window.makeKeyAndOrderFront_(nil);
-
-		app.activateIgnoringOtherApps_(YES);
+		let current_app = NSRunningApplication::currentApplication(nil);
+		current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
 		app.run();
 	}
 }

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -18,6 +18,7 @@ pub use core_graphics::base::CGFloat;
 pub use core_graphics::geometry::CGPoint;
 
 pub use self::NSApplicationActivationPolicy::*;
+pub use self::NSApplicationActivationOptions::*;
 pub use self::NSWindowMask::*;
 pub use self::NSBackingStoreType::*;
 pub use self::NSOpenGLPixelFormatAttribute::*;
@@ -67,6 +68,12 @@ pub unsafe fn NSApp() -> id {
 pub enum NSApplicationActivationPolicy {
     NSApplicationActivationPolicyRegular = 0,
     NSApplicationActivationPolicyERROR = -1
+}
+
+#[repr(u64)]
+pub enum NSApplicationActivationOptions {
+    NSApplicationActivateAllWindows = 1 << 0,
+    NSApplicationActivateIgnoringOtherApps = 1 << 1
 }
 
 #[repr(u64)]
@@ -284,6 +291,19 @@ impl NSApplication for id {
 
     unsafe fn stop_(self, sender: id) {
         msg_send![self, stop:sender]
+    }
+}
+
+pub trait NSRunningApplication { 
+    unsafe fn currentApplication(_: Self) -> id {
+        msg_send![class("NSRunningApplication"), currentApplication]
+    }
+    unsafe fn activateWithOptions_(self, options: NSApplicationActivationOptions) -> BOOL;
+}
+
+impl NSRunningApplication for id {
+    unsafe fn activateWithOptions_(self, options: NSApplicationActivationOptions) -> BOOL {
+        msg_send![self, activateWithOptions:options as NSUInteger]
     }
 }
 


### PR DESCRIPTION
Issue #98 and a comment in issue #30 both note that the example app has no menu bar when the app starts. This PR changes the activation logic to use NSRunningApplication instead of NSApplication to do the activation. On my Yosemite machine, this causes the menu bar to appear when the example app is started.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/cocoa-rs/102)
<!-- Reviewable:end -->
