### PR TITLE
Remove now default 'sudo: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os: osx
 
 language: rust
-sudo: false
 
 branches:
   except:


### PR DESCRIPTION
`sudo: false` is now default on Travis CI

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/cocoa-rs/114)
<!-- Reviewable:end -->
