### PR TITLE
Bump to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cocoa"
 description = "Bindings to Cocoa for OS X"
 homepage = "https://github.com/servo/cocoa-rs"
 repository = "https://github.com/servo/cocoa-rs"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 


### PR DESCRIPTION
Version 0.3.4 should be yanked because bitflags >= 0.6 is incompatible with Rust <1.8
and this breaks downstream crates.

Unfortunately, we can't depend on bitflags >=0.5, <0.8 because it doesn't compile with
bitflags 0.5-6 because of https://github.com/rust-lang-nursery/bitflags/issues/39.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/cocoa-rs/128)
<!-- Reviewable:end -->
