### PR TITLE
Remove legacy items from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,4 @@
 *~
-*#
-*.o
-*.a
-*.so
-*.dylib
-*.dSYM
-*.dll
-*.dummy
-cocoa-test
 build
 /target
 /Cargo.lock


### PR DESCRIPTION
The items being removed were added in da80902 for temporary files generated by `make`. But the Makefile is later removed in #36, and thus these items are no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/cocoa-rs/148)
<!-- Reviewable:end -->
