### PR TITLE
Implement NSWindowStyleMask as bitflags

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -37,7 +37,7 @@ fn main() {
         let window = NSWindow::alloc(nil)
             .initWithContentRect_styleMask_backing_defer_(NSRect::new(NSPoint::new(0., 0.),
                                                                       NSSize::new(200., 200.)),
-                                                          NSTitledWindowMask as NSUInteger,
+                                                          NSTitledWindowMask,
                                                           NSBackingStoreBuffered,
                                                           NO)
             .autorelease();

--- a/examples/tab_view.rs
+++ b/examples/tab_view.rs
@@ -67,11 +67,11 @@ unsafe fn create_app(title: id, content: id) -> id {
     // create Window
     let window = NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(
 		NSRect::new(NSPoint::new(0., 0.), NSSize::new(200., 200.)),
-		NSTitledWindowMask as NSUInteger |
-            NSClosableWindowMask as NSUInteger |
-            NSResizableWindowMask as NSUInteger |
-            NSMiniaturizableWindowMask as NSUInteger |
-            NSUnifiedTitleAndToolbarWindowMask as NSUInteger,
+		NSTitledWindowMask |
+            NSClosableWindowMask |
+            NSResizableWindowMask |
+            NSMiniaturizableWindowMask |
+            NSUnifiedTitleAndToolbarWindowMask,
 		NSBackingStoreBuffered,
 		NO
 	).autorelease();

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -1048,8 +1048,8 @@ impl NSWindow for id {
 
     // Configuring Windows
 
-        let styleMask = msg_send![self, styleMask];
     unsafe fn styleMask(self) -> NSWindowStyleMask {
+        let styleMask = NSWindowStyleMask::from_bits_truncate(msg_send![self, styleMask]);
         styleMask
     }
 

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -141,7 +141,7 @@ pub enum NSApplicationTerminateReply {
 }
 
 bitflags! {
-    pub flags NSWindowMask: NSUInteger {
+    pub flags NSWindowStyleMask: NSUInteger {
         const NSBorderlessWindowMask      = 0,
         const NSTitledWindowMask          = 1 << 0,
         const NSClosableWindowMask        = 1 << 1,
@@ -798,19 +798,19 @@ pub trait NSWindow {
     // Creating Windows
     unsafe fn initWithContentRect_styleMask_backing_defer_(self,
                                                            rect: NSRect,
-                                                           style: NSWindowMask,
+                                                           style: NSWindowStyleMask,
                                                            backing: NSBackingStoreType,
                                                            defer: BOOL) -> id;
     unsafe fn initWithContentRect_styleMask_backing_defer_screen_(self,
                                                                   rect: NSRect,
-                                                                  style: NSWindowMask,
+                                                                  style: NSWindowStyleMask,
                                                                   backing: NSBackingStoreType,
                                                                   defer: BOOL,
                                                                   screen: id) -> id;
 
     // Configuring Windows
-    unsafe fn styleMask(self) -> NSWindowMask;
-    unsafe fn setStyleMask_(self, styleMask: NSWindowMask);
+    unsafe fn styleMask(self) -> NSWindowStyleMask;
+    unsafe fn setStyleMask_(self, styleMask: NSWindowStyleMask);
     unsafe fn toggleFullScreen_(self, sender: id);
     unsafe fn worksWhenModal(self) -> BOOL;
     unsafe fn alphaValue(self) -> CGFloat;
@@ -845,9 +845,9 @@ pub trait NSWindow {
     // TODO: Accessing Window Information
 
     // Getting Layout Information
-    unsafe fn contentRectForFrameRect_styleMask_(self, windowFrame: NSRect, windowStyle: NSWindowMask) -> NSRect;
-    unsafe fn frameRectForContentRect_styleMask_(self, windowContentRect: NSRect, windowStyle: NSWindowMask) -> NSRect;
-    unsafe fn minFrameWidthWithTitle_styleMask_(self, windowTitle: id, windowStyle: NSWindowMask) -> CGFloat;
+    unsafe fn contentRectForFrameRect_styleMask_(self, windowFrame: NSRect, windowStyle: NSWindowStyleMask) -> NSRect;
+    unsafe fn frameRectForContentRect_styleMask_(self, windowContentRect: NSRect, windowStyle: NSWindowStyleMask) -> NSRect;
+    unsafe fn minFrameWidthWithTitle_styleMask_(self, windowTitle: id, windowStyle: NSWindowStyleMask) -> CGFloat;
     unsafe fn contentRectForFrameRect_(self, windowFrame: NSRect) -> NSRect;
     unsafe fn frameRectForContentRect_(self, windowContent: NSRect) -> NSRect;
 
@@ -1024,7 +1024,7 @@ impl NSWindow for id {
 
     unsafe fn initWithContentRect_styleMask_backing_defer_(self,
                                                            rect: NSRect,
-                                                           style: NSWindowMask,
+                                                           style: NSWindowStyleMask,
                                                            backing: NSBackingStoreType,
                                                            defer: BOOL) -> id {
         msg_send![self, initWithContentRect:rect
@@ -1035,7 +1035,7 @@ impl NSWindow for id {
 
     unsafe fn initWithContentRect_styleMask_backing_defer_screen_(self,
                                                                   rect: NSRect,
-                                                                  style: NSWindowMask,
+                                                                  style: NSWindowStyleMask,
                                                                   backing: NSBackingStoreType,
                                                                   defer: BOOL,
                                                                   screen: id) -> id {
@@ -1048,12 +1048,12 @@ impl NSWindow for id {
 
     // Configuring Windows
 
-    unsafe fn styleMask(self) -> NSWindowMask {
         let styleMask = msg_send![self, styleMask];
+    unsafe fn styleMask(self) -> NSWindowStyleMask {
         styleMask
     }
 
-    unsafe fn setStyleMask_(self, styleMask: NSWindowMask) {
+    unsafe fn setStyleMask_(self, styleMask: NSWindowStyleMask) {
         msg_send![self, setStyleMask:styleMask.bits]
     }
 
@@ -1176,15 +1176,15 @@ impl NSWindow for id {
 
     // Getting Layout Information
 
-    unsafe fn contentRectForFrameRect_styleMask_(self, windowFrame: NSRect, windowStyle: NSWindowMask) -> NSRect {
+    unsafe fn contentRectForFrameRect_styleMask_(self, windowFrame: NSRect, windowStyle: NSWindowStyleMask) -> NSRect {
         msg_send![self, contentRectForFrameRect:windowFrame styleMask:windowStyle.bits]
     }
 
-    unsafe fn frameRectForContentRect_styleMask_(self, windowContentRect: NSRect, windowStyle: NSWindowMask) -> NSRect {
+    unsafe fn frameRectForContentRect_styleMask_(self, windowContentRect: NSRect, windowStyle: NSWindowStyleMask) -> NSRect {
         msg_send![self, frameRectForContentRect:windowContentRect styleMask:windowStyle.bits]
     }
 
-    unsafe fn minFrameWidthWithTitle_styleMask_(self, windowTitle: id, windowStyle: NSWindowMask) -> CGFloat {
+    unsafe fn minFrameWidthWithTitle_styleMask_(self, windowTitle: id, windowStyle: NSWindowStyleMask) -> CGFloat {
         msg_send![self, minFrameWidthWithTitle:windowTitle styleMask:windowStyle.bits]
     }
 

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -20,7 +20,6 @@ pub use core_graphics::geometry::CGPoint;
 
 pub use self::NSApplicationActivationPolicy::*;
 pub use self::NSApplicationActivationOptions::*;
-pub use self::NSWindowMask::*;
 pub use self::NSBackingStoreType::*;
 pub use self::NSOpenGLPixelFormatAttribute::*;
 pub use self::NSOpenGLPFAOpenGLProfiles::*;
@@ -141,22 +140,22 @@ pub enum NSApplicationTerminateReply {
     NSTerminateLater = 2,
 }
 
-#[repr(u64)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum NSWindowMask {
-    NSBorderlessWindowMask      = 0,
-    NSTitledWindowMask          = 1 << 0,
-    NSClosableWindowMask        = 1 << 1,
-    NSMiniaturizableWindowMask  = 1 << 2,
-    NSResizableWindowMask       = 1 << 3,
+bitflags! {
+    pub flags NSWindowMask: NSUInteger {
+        const NSBorderlessWindowMask      = 0,
+        const NSTitledWindowMask          = 1 << 0,
+        const NSClosableWindowMask        = 1 << 1,
+        const NSMiniaturizableWindowMask  = 1 << 2,
+        const NSResizableWindowMask       = 1 << 3,
 
-    NSTexturedBackgroundWindowMask  = 1 << 8,
+        const NSTexturedBackgroundWindowMask  = 1 << 8,
 
-    NSUnifiedTitleAndToolbarWindowMask  = 1 << 12,
+        const NSUnifiedTitleAndToolbarWindowMask  = 1 << 12,
 
-    NSFullScreenWindowMask      = 1 << 14,
+        const NSFullScreenWindowMask      = 1 << 14,
 
-    NSFullSizeContentViewWindowMask = 1 << 15
+        const NSFullSizeContentViewWindowMask = 1 << 15
+    }
 }
 
 #[repr(u64)]
@@ -799,19 +798,19 @@ pub trait NSWindow {
     // Creating Windows
     unsafe fn initWithContentRect_styleMask_backing_defer_(self,
                                                            rect: NSRect,
-                                                           style: NSUInteger,
+                                                           style: NSWindowMask,
                                                            backing: NSBackingStoreType,
                                                            defer: BOOL) -> id;
     unsafe fn initWithContentRect_styleMask_backing_defer_screen_(self,
                                                                   rect: NSRect,
-                                                                  style: NSUInteger,
+                                                                  style: NSWindowMask,
                                                                   backing: NSBackingStoreType,
                                                                   defer: BOOL,
                                                                   screen: id) -> id;
 
     // Configuring Windows
-    unsafe fn styleMask(self) -> NSUInteger;
-    unsafe fn setStyleMask_(self, styleMask: NSUInteger);
+    unsafe fn styleMask(self) -> NSWindowMask;
+    unsafe fn setStyleMask_(self, styleMask: NSWindowMask);
     unsafe fn toggleFullScreen_(self, sender: id);
     unsafe fn worksWhenModal(self) -> BOOL;
     unsafe fn alphaValue(self) -> CGFloat;
@@ -846,9 +845,9 @@ pub trait NSWindow {
     // TODO: Accessing Window Information
 
     // Getting Layout Information
-    unsafe fn contentRectForFrameRect_styleMask_(self, windowFrame: NSRect, windowStyle: NSUInteger) -> NSRect;
-    unsafe fn frameRectForContentRect_styleMask_(self, windowContentRect: NSRect, windowStyle: NSUInteger) -> NSRect;
-    unsafe fn minFrameWidthWithTitle_styleMask_(self, windowTitle: id, windowStyle: NSUInteger) -> CGFloat;
+    unsafe fn contentRectForFrameRect_styleMask_(self, windowFrame: NSRect, windowStyle: NSWindowMask) -> NSRect;
+    unsafe fn frameRectForContentRect_styleMask_(self, windowContentRect: NSRect, windowStyle: NSWindowMask) -> NSRect;
+    unsafe fn minFrameWidthWithTitle_styleMask_(self, windowTitle: id, windowStyle: NSWindowMask) -> CGFloat;
     unsafe fn contentRectForFrameRect_(self, windowFrame: NSRect) -> NSRect;
     unsafe fn frameRectForContentRect_(self, windowContent: NSRect) -> NSRect;
 
@@ -1025,23 +1024,23 @@ impl NSWindow for id {
 
     unsafe fn initWithContentRect_styleMask_backing_defer_(self,
                                                            rect: NSRect,
-                                                           style: NSUInteger,
+                                                           style: NSWindowMask,
                                                            backing: NSBackingStoreType,
                                                            defer: BOOL) -> id {
         msg_send![self, initWithContentRect:rect
-                                  styleMask:style
+                                  styleMask:style.bits
                                     backing:backing as NSUInteger
                                       defer:defer]
     }
 
     unsafe fn initWithContentRect_styleMask_backing_defer_screen_(self,
                                                                   rect: NSRect,
-                                                                  style: NSUInteger,
+                                                                  style: NSWindowMask,
                                                                   backing: NSBackingStoreType,
                                                                   defer: BOOL,
                                                                   screen: id) -> id {
         msg_send![self, initWithContentRect:rect
-                                  styleMask:style
+                                  styleMask:style.bits
                                     backing:backing as NSUInteger
                                       defer:defer
                                      screen:screen]
@@ -1049,12 +1048,13 @@ impl NSWindow for id {
 
     // Configuring Windows
 
-    unsafe fn styleMask(self) -> NSUInteger {
-        msg_send![self, styleMask]
+    unsafe fn styleMask(self) -> NSWindowMask {
+        let styleMask = msg_send![self, styleMask];
+        styleMask
     }
 
-    unsafe fn setStyleMask_(self, styleMask: NSUInteger) {
-        msg_send![self, setStyleMask:styleMask]
+    unsafe fn setStyleMask_(self, styleMask: NSWindowMask) {
+        msg_send![self, setStyleMask:styleMask.bits]
     }
 
     unsafe fn toggleFullScreen_(self, sender: id) {
@@ -1176,16 +1176,16 @@ impl NSWindow for id {
 
     // Getting Layout Information
 
-    unsafe fn contentRectForFrameRect_styleMask_(self, windowFrame: NSRect, windowStyle: NSUInteger) -> NSRect {
-        msg_send![self, contentRectForFrameRect:windowFrame styleMask:windowStyle]
+    unsafe fn contentRectForFrameRect_styleMask_(self, windowFrame: NSRect, windowStyle: NSWindowMask) -> NSRect {
+        msg_send![self, contentRectForFrameRect:windowFrame styleMask:windowStyle.bits]
     }
 
-    unsafe fn frameRectForContentRect_styleMask_(self, windowContentRect: NSRect, windowStyle: NSUInteger) -> NSRect {
-        msg_send![self, frameRectForContentRect:windowContentRect styleMask:windowStyle]
+    unsafe fn frameRectForContentRect_styleMask_(self, windowContentRect: NSRect, windowStyle: NSWindowMask) -> NSRect {
+        msg_send![self, frameRectForContentRect:windowContentRect styleMask:windowStyle.bits]
     }
 
-    unsafe fn minFrameWidthWithTitle_styleMask_(self, windowTitle: id, windowStyle: NSUInteger) -> CGFloat {
-        msg_send![self, minFrameWidthWithTitle:windowTitle styleMask:windowStyle]
+    unsafe fn minFrameWidthWithTitle_styleMask_(self, windowTitle: id, windowStyle: NSWindowMask) -> CGFloat {
+        msg_send![self, minFrameWidthWithTitle:windowTitle styleMask:windowStyle.bits]
     }
 
     unsafe fn contentRectForFrameRect_(self, windowFrame: NSRect) -> NSRect {


### PR DESCRIPTION
RE https://github.com/servo/cocoa-rs/issues/159

`NSWindowStyleMask`, as an enumeration in Objective-C, degrades to `NSUInteger` and is therefore bitwise-combinable, though it loses type information. Instead of implementing `NSWindowStyleMask` as a packed-data object with a `u64` representational form, we ought to employ bit flags to generate a strong type that remains combinable in the manner Cocoa programmers are accustomed to. Also easier than manually implementing `std::ops::BitOr` for the type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/cocoa-rs/160)
<!-- Reviewable:end -->