### PR TITLE
example: add space between quit and process name

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -22,7 +22,7 @@ fn main() {
 
         // create Application menu
         let app_menu = NSMenu::new(nil).autorelease();
-        let quit_prefix = NSString::alloc(nil).init_str("Quit");
+        let quit_prefix = NSString::alloc(nil).init_str("Quit ");
         let quit_title =
             quit_prefix.stringByAppendingString_(NSProcessInfo::processInfo(nil).processName());
         let quit_action = selector("terminate:");


### PR DESCRIPTION
Add a space between "Quit" and the process name in the menu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/cocoa-rs/174)
<!-- Reviewable:end -->
