### PR TITLE
Add documentation URL to manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name = "cocoa"
 description = "Bindings to Cocoa for OS X"
 homepage = "https://github.com/servo/cocoa-rs"
+documentation = "https://docs.rs/cocoa/"
 repository = "https://github.com/servo/cocoa-rs"
 version = "0.14.0"
 authors = ["The Servo Project Developers"]


### PR DESCRIPTION
For some reason, https://docs.rs/cocoa redirects to a page that says "The requested resource does not exist". Not sure if this would fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/cocoa-rs/182)
<!-- Reviewable:end -->
